### PR TITLE
Add release workflow for tag-based GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Create GitHub Release
+      run: gh release create "${{ github.ref_name }}" --generate-notes
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that automatically creates a GitHub release with generated notes when a `v*` tag is pushed.

## Test plan
- Push a `v*` tag (e.g. `v0.0.2`) and verify a GitHub release is created with auto-generated notes.